### PR TITLE
feat: introduce cache layer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,7 +215,7 @@ async function handleRequest(event) {
     console.log('Edge Cache hit!')
     // Repack response to make headers mutable
     response = new Response(response.body, response)
-    // Set Cloudflare Egde cache hit
+    // Set Cloudflare Edge cache hit
     response.headers.set('CF-Cache-Status', 'HIT')
     // Browser Cache-Control TTL, set to 0 to disable Browser cache
     response.headers.set('Cache-Control', 'max-age=0')
@@ -285,10 +285,10 @@ async function handleRequest(event) {
     </html>
     `
     response = new Response(landing, respInit.greet)
-    // Cloudflare Egde Cache-Control TTL, 4-hours for Landing page
+    // Cloudflare Edge Cache-Control TTL, 4-hours for Landing page
     response.headers.set('Cache-Control', 'public, max-age=14400')
     event.waitUntil(cache.put(cacheKey, response.clone()))
-    // Set Cloudflare Egde cache miss
+    // Set Cloudflare Edge cache miss
     response.headers.set('CF-Cache-Status', 'MISS')
     return response
   }
@@ -320,11 +320,11 @@ async function handleRequest(event) {
     data: result,
   }
   response = new Response(JSON.stringify(finalResp), respInit.ok)
-  // Cloudflare Egde Cache-Control TTL, 5-minutes for statistics response
+  // Cloudflare Edge Cache-Control TTL, 5-minutes for statistics response
   response.headers.set('Cache-Control', 'public, max-age=300')
   // Store the fetched statistics as cacheKey
   event.waitUntil(cache.put(cacheKey, response.clone()))
-  // Set Cloudflare Egde cache miss
+  // Set Cloudflare Edge cache miss
   response.headers.set('CF-Cache-Status', 'MISS')
   // Browser Cache-Control TTL, set to 0 to disable Browser Cache
   response.headers.set('Cache-Control', 'max-age=0')

--- a/src/utils/handlers/afdian.js
+++ b/src/utils/handlers/afdian.js
@@ -7,7 +7,12 @@ const fetchAfdianStat = slug => {
   // afdian api module takes user slug as query parameter
   const url = `https://afdian.net/api/user/get-profile-by-slug?url_slug=${slug}`
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/bilibili.js
+++ b/src/utils/handlers/bilibili.js
@@ -7,7 +7,12 @@ const fetchBilibiliStat = uid => {
   // Bilibili api module takes user uid as query parameter
   const url = `https://api.bilibili.com/x/relation/stat?vmid=${uid}&isonp=jsonp`
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/coolapk.js
+++ b/src/utils/handlers/coolapk.js
@@ -32,7 +32,12 @@ const fetchCoolapkStat = uid => {
     'X-Dark-Mode': '0',
     'X-App-Token': token,
   }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/feedly.js
+++ b/src/utils/handlers/feedly.js
@@ -10,7 +10,12 @@ const fetchFeedlyStats = rss => {
   // feedly api module takes an encoded `feed/{link}` URL as query parameter
   const url = `https://feedly.com/v3/recommendations/feeds/${req}`
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/feedsPub.js
+++ b/src/utils/handlers/feedsPub.js
@@ -13,7 +13,12 @@ const fetchFeedsPubStats = rss => {
 
   const url = `https://api.feeds.pub/graphql?query=query%20feed(%24id%3A%20String!)%7B%20feed(id%3A%20%24id)%20%7B%20followerCount%20%7D%20%7D&variables=%7B%22id%22%3A%20%22${req}%22%7D&operationName=feed`
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/github.js
+++ b/src/utils/handlers/github.js
@@ -6,9 +6,13 @@
 const fetchGitHubStats = login => {
   // GitHub api module takes user login as query parameter
   const url = `https://api.github.com/users/${login}`
-
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/inoreader.js
+++ b/src/utils/handlers/inoreader.js
@@ -10,7 +10,12 @@ const fetchInoreaderStats = rss => {
   // inoreader api module takes an encoded `feed/{link}` URL as query parameter
   const url = `https://www.inoreader.com/autocomplete.php?origin=smart_search&term=${req}`
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/instagram.js
+++ b/src/utils/handlers/instagram.js
@@ -8,7 +8,12 @@ const fetchInstagramStats = username => {
   const url = `https://www.instagram.com/${username}/?__a=1`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/jike.js
+++ b/src/utils/handlers/jike.js
@@ -10,7 +10,13 @@ const fetchJikeData = async id => {
   const url = `https://m.okjike.com/users/${id}`
   const headers = { 'User-Agent': 'substat-bot' }
 
-  const resp = await fetch(url, { headers })
+  const resp = await fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
+
   if (resp.status !== 200) {
     return { error: 'failed', data: 'Jike API failed' }
   }

--- a/src/utils/handlers/medium.js
+++ b/src/utils/handlers/medium.js
@@ -8,7 +8,12 @@ const fetchMediumStats = username => {
   const url = `https://medium.com/${username}?format=json`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/neteaseMusic.js
+++ b/src/utils/handlers/neteaseMusic.js
@@ -7,7 +7,12 @@ const fetchNeteaseMusic = uid => {
   // Netease Music api module takes user uid as query parameter
   const url = `https://music.163.com/api/v1/user/detail/${uid}`
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/newsblur.js
+++ b/src/utils/handlers/newsblur.js
@@ -13,7 +13,12 @@ const fetchNewsBlurStats = (rss, cookie) => {
   // NewsBlur api module takes an encoded `feed/{link}` URL as query parameter
   const url = `https://newsblur.com/rss_feeds/search_feed?address=${req}`
   const headers = { 'User-Agent': 'substat-bot', Cookie: cookie }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/reddit.js
+++ b/src/utils/handlers/reddit.js
@@ -8,7 +8,12 @@ const fetchRedditStats = username => {
   const url = `https://www.reddit.com/user/${username}/about.json`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/sspai.js
+++ b/src/utils/handlers/sspai.js
@@ -6,9 +6,13 @@
 const fetchSspaiStats = slug => {
   // sspai api module takes user slug as query parameter
   const url = `https://sspai.com/api/v1/user/slug/info/get?slug=${slug}`
-
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/steam.js
+++ b/src/utils/handlers/steam.js
@@ -11,7 +11,12 @@ const fetchSteamGamesStats = steamId => {
   const url = `https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=${STEAM_API_KEY}&steamid=${steamId}`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/telegram.js
+++ b/src/utils/handlers/telegram.js
@@ -11,7 +11,12 @@ const fetchTelegramStat = chatId => {
   const url = `https://api.telegram.org/bot${TG_BOT_TOKEN}/getChatMembersCount?chat_id=@${chatId}`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/twitter.js
+++ b/src/utils/handlers/twitter.js
@@ -9,7 +9,12 @@ const fetchTwitterStats = name => {
   const url = `https://cdn.syndication.twimg.com/widgets/followbutton/info.json?screen_names=${name}`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/unsplash.js
+++ b/src/utils/handlers/unsplash.js
@@ -10,7 +10,12 @@ const fetchUnsplashStats = username => {
   const url = `https://api.unsplash.com/users/${username}?client_id=${UNSPLASH_ACCESS_TOKEN}`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/weibo.js
+++ b/src/utils/handlers/weibo.js
@@ -8,7 +8,12 @@ const fetchWeiboStat = userId => {
   const url = `https://m.weibo.cn/api/container/getIndex?containerid=100505${userId}`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/wikipediaZh.js
+++ b/src/utils/handlers/wikipediaZh.js
@@ -8,7 +8,12 @@ const fetchWikipediaZhStats = name => {
   const url = `https://zh.wikipedia.org/w/api.php?action=query&list=users&ususers=${name}&usprop=editcount&format=json`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**

--- a/src/utils/handlers/zhihu.js
+++ b/src/utils/handlers/zhihu.js
@@ -9,7 +9,12 @@ const fetchZhihuStat = urlToken => {
   const url = `https://www.zhihu.com/api/v4/members/${urlToken}?include=follower_count`
 
   const headers = { 'User-Agent': 'substat-bot' }
-  return fetch(url, { headers })
+  return fetch(url, {
+    headers,
+    cf: {
+      cacheEverything: true,
+    },
+  })
 }
 
 /**


### PR DESCRIPTION
Resolve #23 

substats 目前缺乏缓存机制，用户端每一次访问的返回，都是 worker 实时向上游各个服务/接口请求处理后再下发。导致存在 https://github.com/spencerwooo/Substats/issues/23#issuecomment-731524402 提及的问题。

> 怪不得每次都得等“半分钟”😂，source 越多越久。缓存也可以减少对上游服务的请求频次，降低被封禁风险。

Cloudflare Workers 引入缓存机制的话，涉及到三层缓存，由下往上分别是 Fetch API 层，Edge CDN 层以及 Browser 层。

Browser 层就是设置在用户端浏览器进行缓存，这是最末端一层，这一层缓存受控能力弱，用户”一不小心“进行 F5 强刷就能逃逸。使用这一层缓存的效果不大，所以为了简化逻辑，我禁用了 Browser 层缓存。

最下层的 Fetch API 层缓存，使用得当的话，理论上能对每一个上游服务/接口的请求进行细粒度的缓存控制。但是 Cloudflare Workers Fetch API 层缓存用得爽需要[氪金](https://developers.cloudflare.com/workers/examples/cache-using-fetch#override-based-on-origin-response-code)。所以这层我只显示地告诉 Cloudflare 去尝试缓存所有 Fetch 请求，但不作保证。

所谓 Edge CDN 层，指利用 Cloudflare 提供的 Cache API，手动告诉各边缘节点按照给定的设置，缓存 worker 本身下发的响应。这一层不能像 Fetch API 层那样做每一个上游服务粒度的缓存控制（因为是根据请求 URL 做缓存，所以 `/?source=github&queryKey=spencerwooo` 与 `/?source=github&queryKey=spencerwooo&source=sspai&queryKey=spencerwoo` 会被视作两个缓存项，这里下层就不会对 github 接口请求做缓存），但是对比 Browser 层相对可控，使用 F5 不可逃逸。考虑到 substats 本身在接口数据更新方面可能比较敏感，所以我只对每一个实际的 substats API 请求设置了[ **5 分钟**](https://github.com/spencerwooo/Substats/pull/27/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R323-R324)的缓存时长（可视情况调整，感觉 30 分钟感知度应该也不会太大）。一定程度上还是能缓解  https://github.com/spencerwooo/Substats/issues/23 的问题。

发起 substats API 请求后，观察响应头中的 `CF-Cache-Status` 可判断缓存是否生效。