### PR TITLE
Replace the Weibo API

### DIFF
--- a/src/services/weibo.js
+++ b/src/services/weibo.js
@@ -3,16 +3,41 @@
  *
  * @param {string} userId Weibo user ID
  */
-const fetchWeiboStat = userId => {
+ const fetchWeiboStat = (userId,sub,subp) => {
   // Weibo API expects a user ID
-  const url = `https://m.weibo.cn/api/container/getIndex?containerid=100505${userId}`
+  const url = `https://weibo.com/ajax/profile/info?uid=${userId}`
 
-  const headers = { 'User-Agent': 'substat-bot' }
+  const headers = { 
+    'User-Agent': 'substat-bot',
+    'cookie': `SUB=${sub}; SUBP=${subp}`
+  }
   return fetch(url, {
     headers,
     cf: {
       cacheEverything: true,
     },
+  })
+}
+
+const getTid = () => {
+  const url = 'https://passport.weibo.com/visitor/genvisitor'
+  const headers = { 
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36',
+    'Content-Type': 'application/x-www-form-urlencoded' }
+  return fetch(url,{
+    body: 'cb=gen_callback&fp={"os":"1","browser":"Chrome96,0,4664,110","fonts":"undefined","screenInfo":"1536*864*24","plugins":"Portable Document Format::internal-pdf-viewer::PDF Viewer|Portable Document Format::internal-pdf-viewer::Chrome PDF Viewer|Portable Document Format::internal-pdf-viewer::Chromium PDF Viewer|Portable Document Format::internal-pdf-viewer::Microsoft Edge PDF Viewer|Portable Document Format::internal-pdf-viewer::WebKit built-in PDF"}',
+    method: 'POST',
+    headers,
+  })
+}
+
+const getVisitorCookies = tid => {
+  const url = `https://passport.weibo.com/visitor/visitor?a=incarnate&t=${tid}&w=2&c=095&gc=&cb=cross_domain&from=weibo&_rand=${Math.random()}`
+  const headers = { 
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36',
+  }
+  return fetch(url, {
+    headers,
   })
 }
 
@@ -22,8 +47,15 @@ const fetchWeiboStat = userId => {
  * @param {string} userId Weibo user ID
  */
 export const weiboHandler = async userId => {
-  const response = await fetchWeiboStat(userId)
+  const genvisitorRes = await getTid()
+  const genvisitorJson = JSON.parse(((await genvisitorRes.text()).replace('window.gen_callback && gen_callback(', '')).replace(');',''))
+
+  const visitorCookiesRes = await getVisitorCookies(genvisitorJson.data.tid)
+  const visitorCookiesJson = JSON.parse(((await visitorCookiesRes.text()).replace('window.cross_domain && cross_domain(','')).replace(');',''))
+  
+  const response = await fetchWeiboStat(userId,visitorCookiesJson.data.sub,visitorCookiesJson.data.subp)
   const stats = await response.json()
+
   const res = {
     source: 'weibo',
     subs: 0,
@@ -31,6 +63,7 @@ export const weiboHandler = async userId => {
     failedMsg: '',
   }
 
+  
   if (!stats.ok) {
     // Weibo user not found or API failed
     res.failed = true
@@ -38,7 +71,7 @@ export const weiboHandler = async userId => {
     res.failedMsg = stats.msg
   } else {
     // Weibo user found
-    res.subs = stats.data.userInfo.followers_count
+    res.subs = stats.data.user.followers_count//stats.data.userInfo.followers_count
   }
 
   return res


### PR DESCRIPTION
When the followers_count > 10,000, the previous Weibo API does not return the exact number

`{
    "ok": 1,
    "data": {
        "userInfo": {
            "followers_count": "87\u4e07",
            "followers_count_str": "87\u4e07"
        }
    }
}`

Replace the Weibo API with ```https://weibo.com/ajax/profile/info?uid=${userId}```