### PR TITLE
fix: feedly fetchUrl

### DIFF
--- a/worker/src/providers/feedly.ts
+++ b/worker/src/providers/feedly.ts
@@ -12,7 +12,7 @@ export default async function feedlyProvider(
   return commonProviderHandler<FeedlyResponse>({
     providerName: 'feedly',
     queryKey: key,
-    fetchUrl: `https://feedly.com/v3/recommendations/feeds/feed%2F${key}?count=0`,
+    fetchUrl: `https://feedly.com/v3/recommendations/feeds/feed%2F${encodeURIComponent(key)}?count=0`,
     countObjPath: 'source.subscribers',
     errorMessageObjPath: 'no error message fallback to default',
     isResponseValid: d => 'source' in d,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The feedly request address is incorrect, it has been fixed here.

### Linked Issues

<!-- Please reference the issue that it solves if there is any (e.g. `fixes #123`) -->

fixes #55

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
