### PR TITLE
更新B站相关接口(fix #62)

### DIFF
--- a/worker/src/providers/bilibili.ts
+++ b/worker/src/providers/bilibili.ts
@@ -1,17 +1,18 @@
 import type { SubstatsResponse } from '@/types'
 import { commonProviderHandler } from '.'
 
-// https://api.bilibili.com/x/relation/stat?vmid=401742377&isonp=jsonp
+// https://api.bilibili.com/x/web-interface/card?mid=401742377&isonp=jsonp
 type BilibiliResponse =
   | {
       code: 0
       message: string
       ttl: number
       data: {
-        mid: number
-        following: number
-        whisper: number
-        black: number
+        card: object,
+        like_num: number
+        following: boolean
+        archive_count: number
+        article_count: number
         follower: number
       }
     }
@@ -23,7 +24,7 @@ export default async function bilibiliProvider(
   return commonProviderHandler<BilibiliResponse>({
     providerName: 'bilibili',
     queryKey: key,
-    fetchUrl: `https://api.bilibili.com/x/relation/stat?vmid=${key}&isonp=jsonp`,
+    fetchUrl: `https://api.bilibili.com/x/web-interface/card?mid=${key}`,
     countObjPath: 'data.follower',
     errorMessageObjPath: 'message',
     isResponseValid: d => d.code === 0 && 'data' in d,


### PR DESCRIPTION
### Description

鉴于B站原接口突然跪了，更新一个新的接口

### Linked Issues

- #62 

### Additional context

自测：

```console
$ curl "http://127.0.0.1:8787/stats/bilibili/1415334"
{"source":"bilibili","key":"1415334","failed":false,"count":1280}
```

成功了。

旧版接口（`api.spencerwoo.com`）我不太了解，我尝试了一下用不了。

```console
$ curl "http://127.0.0.1:8787/substats/?source=bilibili&queryKey=1415334"
404 Not Found
```
